### PR TITLE
Add Docker Compose support with localstack service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### DOCKER COMPOSE SUPPORT ###
+volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack:2.0
+    ports:
+      - "4566:4566"
+    environment:
+      - DEBUG=${DEBUG-}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <java.version>17</java.version>
         <spring-cloud.version>2022.0.3</spring-cloud.version>
         <spring-cloud-aws.version>3.0.2</spring-cloud-aws.version>
-
     </properties>
     <dependencies>
         <dependency>
@@ -31,6 +30,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-docker-compose</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This commit introduces Docker Compose support by adding a `docker-compose.yml` file. The file includes configuration for LocalStack 2.0, enabling local development and testing against AWS cloud services. A volume is also defined for LocalStack to provide persistent storage. This volume path is added to the `.gitignore` file to prevent it from being committed to the repository.

Additionally, the `pom.xml` is updated to include the `spring-boot-docker-compose` dependency, providing support for Docker Compose within the Spring Boot application. Note that an unused property was removed from this file as well.